### PR TITLE
Switch to release in deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -49,9 +49,9 @@ chmod +x $CSHARP_BIN/ContinuousTests/ContinuousTests.exe
 
 echo $BINARYDIR
 
-xbuild OpenIDE.sln /target:rebuild /property:OutDir=$BINARYDIR/;Configuration=Release;
-xbuild OpenIDE.CodeEngine.sln /target:rebuild /property:OutDir=$BINARYDIR/;Configuration=Release;
-xbuild Languages/CSharp/CSharp.sln /target:rebuild /property:OutDir=$BINARYDIR/;Configuration=Release;
+xbuild OpenIDE.sln /target:rebuild /property:OutDir=$BINARYDIR/ /p:Configuration=Release;
+xbuild OpenIDE.CodeEngine.sln /target:rebuild /property:OutDir=$BINARYDIR/ /p:Configuration=Release;
+xbuild Languages/CSharp/CSharp.sln /target:rebuild /property:OutDir=$BINARYDIR/ /p:Configuration=Release;
 
 cp $BINARYDIR/CoreExtensions.dll $DEPLOYDIR/
 cp $BINARYDIR/oi.exe $DEPLOYDIR/

--- a/oi/oi
+++ b/oi/oi
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-oi.exe "$@"
+mono oi.exe "$@"


### PR DESCRIPTION
Switch to release build was broken in deploy.sh at least on mono 2.10.9 - it was doing Debug build.
